### PR TITLE
feat: 허브 도메인 API 추가 

### DIFF
--- a/application/hub/build.gradle
+++ b/application/hub/build.gradle
@@ -16,6 +16,9 @@ repositories {
 }
 
 dependencies {
+    implementation project(':component:component-jpa')
+    implementation project(':component:component-exception')
+
     // spring validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -27,9 +30,6 @@ dependencies {
 
     // docker compose support
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-
-    implementation(project(':component:component-jpa'))
-    implementation(project(':component:component-exception'))
 }
 
 tasks.named('test') {

--- a/application/hub/http/hub-api.http
+++ b/application/hub/http/hub-api.http
@@ -1,0 +1,25 @@
+### 허브 생성
+POST http://localhost:8081/hubs
+Content-Type: application/json
+
+{
+  "address": {
+    "roadAddress": "서울특별시 강남구 강남대로 1234",
+    "detailAddress": "강남빌딩 1234호",
+    "zipcode": "12345"
+  },
+  "coordinate": {
+    "latitude": 37.123456,
+    "longitude": 127.123456
+  }
+}
+
+> {%
+  client.global.set("hubId", response.body.data.id); // sampleId 라는 변수에 response.body.data.id 값을 저장
+%}
+
+### 허브 리스트 조회
+GET http://localhost:8081/hubs
+
+### 허브 단건 조회
+GET http://localhost:8081/hubs/{{hubId}}

--- a/application/hub/src/main/java/animal/HubApplication.java
+++ b/application/hub/src/main/java/animal/HubApplication.java
@@ -1,4 +1,4 @@
-package ex;
+package animal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/application/hub/src/main/java/animal/application/HubService.java
+++ b/application/hub/src/main/java/animal/application/HubService.java
@@ -9,7 +9,6 @@ import animal.infrastructure.HubRepository;
 import animal.mapper.HubMapper;
 import exception.GlobalException;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,8 +27,8 @@ public class HubService {
     /**
      * 허브 단건 조회
      */
-    public GetHubRes getHub(UUID id) {
-        Hub hub = hubRepository.findById(HubId.of(id))
+    public GetHubRes getHub(HubId hubId) {
+        Hub hub = hubRepository.findById(hubId)
             .orElseThrow(() -> new GlobalException(ErrorCase.NOT_FOUND));
 
         return hubMapper.toGetHubRes(hub);

--- a/application/hub/src/main/java/animal/application/HubService.java
+++ b/application/hub/src/main/java/animal/application/HubService.java
@@ -38,7 +38,7 @@ public class HubService {
     /**
      * 허브 리스트 조회
      */
-    public List<GetHubRes> getHubResList() {
+    public List<GetHubRes> getHubList() {
 
         return hubRepository.findAll()
             .stream()

--- a/application/hub/src/main/java/animal/application/HubService.java
+++ b/application/hub/src/main/java/animal/application/HubService.java
@@ -1,0 +1,64 @@
+package animal.application;
+
+import animal.domain.Hub;
+import animal.domain.HubId;
+import animal.dto.HubRequest.CreateHubReq;
+import animal.dto.HubResponse.CreateHubRes;
+import animal.dto.HubResponse.GetHubRes;
+import animal.infrastructure.HubRepository;
+import animal.mapper.HubMapper;
+import exception.GlobalException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import response.ErrorCase;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubService {
+
+    private final HubMapper hubMapper;
+    private final HubRepository hubRepository;
+
+    /**
+     * 허브 단건 조회
+     */
+    public GetHubRes getHub(UUID id) {
+        Hub hub = hubRepository.findById(HubId.of(id))
+            .orElseThrow(() -> new GlobalException(ErrorCase.NOT_FOUND));
+
+        return hubMapper.toGetHubRes(hub);
+    }
+
+    /**
+     * 허브 리스트 조회
+     */
+    public List<GetHubRes> getHubResList() {
+
+        return hubRepository.findAll()
+            .stream()
+            .map(hubMapper::toGetHubRes)
+            .toList();
+    }
+
+    /**
+     * 허브 생성
+     */
+    @Transactional
+    public CreateHubRes createHub(CreateHubReq createHubReq) {
+
+        Hub hub = Hub.builder()
+            .address(createHubReq.address())
+            .coordinate(createHubReq.coordinate())
+            .build();
+
+        Hub savedHub = hubRepository.save(hub);
+
+        return hubMapper.toCreateHubRes(savedHub);
+    }
+}

--- a/application/hub/src/main/java/animal/domain/Address.java
+++ b/application/hub/src/main/java/animal/domain/Address.java
@@ -1,0 +1,32 @@
+package animal.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+
+    @Column(name = "road_address", nullable = false)
+    private String roadAddress;
+
+    @Column(name = "detail_address", nullable = false)
+    private String detailAddress;
+
+    @Column(name = "zipcode", length = 100, nullable = false)
+    private String zipcode;
+
+    @Builder
+    private Address(String roadAddress, String detailAddress, String zipcode) {
+        this.roadAddress = roadAddress;
+        this.detailAddress = detailAddress;
+        this.zipcode = zipcode;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/Coordinate.java
+++ b/application/hub/src/main/java/animal/domain/Coordinate.java
@@ -1,0 +1,47 @@
+package animal.domain;
+
+import exception.GlobalException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import response.ErrorCase;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coordinate {
+
+    private static final double MAX_LATITUDE = 90.0;
+    private static final double MIN_LATITUDE = -90.0;
+    private static final double MAX_LONGITUDE = 180.0;
+    private static final double MIN_LONGITUDE = -180.0;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Builder
+    private Coordinate(Double latitude, Double longitude) {
+        if (!isValidLatitude(latitude) || !isValidLongitude(longitude)) {
+            throw new GlobalException(ErrorCase.INVALID_INPUT);
+        }
+
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    private boolean isValidLatitude(Double latitude) {
+        return MIN_LATITUDE <= latitude && latitude <= MAX_LATITUDE;
+    }
+
+    private boolean isValidLongitude(Double longitude) {
+        return MIN_LONGITUDE <= longitude && longitude <= MAX_LONGITUDE;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/Hub.java
+++ b/application/hub/src/main/java/animal/domain/Hub.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class Hub extends BaseEntity {
 
     @EmbeddedId
-    private final HubId id = new HubId();
+    private final HubId id = HubId.ofRandom();
 
     @Embedded
     private Address address;

--- a/application/hub/src/main/java/animal/domain/Hub.java
+++ b/application/hub/src/main/java/animal/domain/Hub.java
@@ -1,0 +1,33 @@
+package animal.domain;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jpa.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_hub")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hub extends BaseEntity {
+
+    @EmbeddedId
+    private final HubId id = new HubId();
+
+    @Embedded
+    private Address address;
+
+    @Embedded
+    private Coordinate coordinate;
+
+    @Builder
+    private Hub(Address address, Coordinate coordinate) {
+        this.address = address;
+        this.coordinate = coordinate;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/HubId.java
+++ b/application/hub/src/main/java/animal/domain/HubId.java
@@ -2,8 +2,6 @@ package animal.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import java.io.Serializable;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -21,12 +19,17 @@ import lombok.NoArgsConstructor;
 public class HubId implements Serializable { // JPA 식별자 타입은 Serializable 구현해야 함
 
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     public static HubId of(UUID id) {
         HubId hubId = new HubId();
         hubId.id = id;
+        return hubId;
+    }
+
+    public static HubId ofRandom() {
+        HubId hubId = new HubId();
+        hubId.id = UUID.randomUUID();
         return hubId;
     }
 }

--- a/application/hub/src/main/java/animal/domain/HubId.java
+++ b/application/hub/src/main/java/animal/domain/HubId.java
@@ -1,0 +1,32 @@
+package animal.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 허브의 id 값객체
+ */
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubId implements Serializable { // JPA 식별자 타입은 Serializable 구현해야 함
+
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    public static HubId of(UUID id) {
+        HubId hubId = new HubId();
+        hubId.id = id;
+        return hubId;
+    }
+}

--- a/application/hub/src/main/java/animal/dto/HubRequest.java
+++ b/application/hub/src/main/java/animal/dto/HubRequest.java
@@ -1,0 +1,19 @@
+package animal.dto;
+
+import animal.domain.Address;
+import animal.domain.Coordinate;
+import jakarta.validation.constraints.NotNull;
+
+public class HubRequest {
+
+    public record CreateHubReq(
+
+        @NotNull(message = "주소는 필수입니다.")
+        Address address,
+        
+        @NotNull(message = "좌푯값은 필수입니다.")
+        Coordinate coordinate
+    ) {
+
+    }
+}

--- a/application/hub/src/main/java/animal/dto/HubResponse.java
+++ b/application/hub/src/main/java/animal/dto/HubResponse.java
@@ -1,0 +1,24 @@
+package animal.dto;
+
+import animal.domain.Address;
+import animal.domain.Coordinate;
+import java.util.UUID;
+
+public class HubResponse {
+
+    public record GetHubRes(
+        UUID id,
+        Address address,
+        Coordinate coordinate
+    ) {
+
+    }
+
+    public record CreateHubRes(
+        UUID id,
+        Address address,
+        Coordinate coordinate
+    ) {
+
+    }
+}

--- a/application/hub/src/main/java/animal/infrastructure/HubRepository.java
+++ b/application/hub/src/main/java/animal/infrastructure/HubRepository.java
@@ -1,0 +1,9 @@
+package animal.infrastructure;
+
+import animal.domain.Hub;
+import animal.domain.HubId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HubRepository extends JpaRepository<Hub, HubId> {
+
+}

--- a/application/hub/src/main/java/animal/mapper/HubMapper.java
+++ b/application/hub/src/main/java/animal/mapper/HubMapper.java
@@ -1,0 +1,19 @@
+package animal.mapper;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+import animal.domain.Hub;
+import animal.dto.HubResponse.CreateHubRes;
+import animal.dto.HubResponse.GetHubRes;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = SPRING)
+public interface HubMapper {
+
+    @Mapping(target = "id", source = "id.id")
+    GetHubRes toGetHubRes(Hub hub);
+
+    @Mapping(target = "id", source = "id.id")
+    CreateHubRes toCreateHubRes(Hub hub);
+}

--- a/application/hub/src/main/java/animal/presentation/HubController.java
+++ b/application/hub/src/main/java/animal/presentation/HubController.java
@@ -1,0 +1,54 @@
+package animal.presentation;
+
+import animal.application.HubService;
+import animal.dto.HubRequest.CreateHubReq;
+import animal.dto.HubResponse.CreateHubRes;
+import animal.dto.HubResponse.GetHubRes;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import response.CommonResponse;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hubs")
+public class HubController {
+
+    private final HubService hubService;
+
+    /**
+     * 허브 단건 조회
+     */
+    @GetMapping("/{hubId}")
+    public CommonResponse<GetHubRes> getHub(@PathVariable("hubId") UUID hubId) {
+        GetHubRes hub = hubService.getHub(hubId);
+        return CommonResponse.success(hub);
+    }
+
+    /**
+     * 허브 리스트 조회
+     */
+    @GetMapping
+    public CommonResponse<List<GetHubRes>> getHubList() {
+        List<GetHubRes> hubList = hubService.getHubResList();
+        return CommonResponse.success(hubList);
+    }
+
+    /**
+     * 허브 생성
+     */
+    @PostMapping
+    public CommonResponse<CreateHubRes> createHub(@Validated @RequestBody CreateHubReq createHubReq) {
+        CreateHubRes hub = hubService.createHub(createHubReq);
+        return CommonResponse.success(hub);
+    }
+}

--- a/application/hub/src/main/java/animal/presentation/HubController.java
+++ b/application/hub/src/main/java/animal/presentation/HubController.java
@@ -1,6 +1,7 @@
 package animal.presentation;
 
 import animal.application.HubService;
+import animal.domain.HubId;
 import animal.dto.HubRequest.CreateHubReq;
 import animal.dto.HubResponse.CreateHubRes;
 import animal.dto.HubResponse.GetHubRes;
@@ -30,7 +31,7 @@ public class HubController {
      */
     @GetMapping("/{hubId}")
     public CommonResponse<GetHubRes> getHub(@PathVariable("hubId") UUID hubId) {
-        GetHubRes hub = hubService.getHub(hubId);
+        GetHubRes hub = hubService.getHub(HubId.of(hubId));
         return CommonResponse.success(hub);
     }
 

--- a/application/hub/src/main/java/animal/presentation/HubController.java
+++ b/application/hub/src/main/java/animal/presentation/HubController.java
@@ -39,7 +39,7 @@ public class HubController {
      */
     @GetMapping
     public CommonResponse<List<GetHubRes>> getHubList() {
-        List<GetHubRes> hubList = hubService.getHubResList();
+        List<GetHubRes> hubList = hubService.getHubList();
         return CommonResponse.success(hubList);
     }
 

--- a/application/hub/src/main/resources/application-dev.yml
+++ b/application/hub/src/main/resources/application-dev.yml
@@ -4,8 +4,8 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:54321/animal
-    username: sa
-    password:
+    username: animal
+    password: 1234
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## 개요

- 허브 도메인의 생성, 조회 API를 추가했습니다. 

## 작업사항

- 허브 도메인 추가 
  - 허브 엔티티 추가 
  - 허브 id 값객체 추가 
  - 주소 값객체 추가 
  - 좌표계 값객체 추가
- 허브 API 추가 
  - 생성 API 추가 
  - 단건 조회 API 추가
  - 리스트 조회 API 추가
- 허브 HTTP 테스트 추가 
  - 생성, 조회 테스트 추가

## 세부사항

- `HubResponse` DTO 객체의 경우, `생성 응답 dto`와 `조회 응답 dto` 필드가 정확히 일치하고, 이후 동일 시점에 변경될 것 같은데, 이 같은 경우 하나로 합칠지 아니면 API마다 하나씩 유지할지도 논의해보면 좋을 것 같습니다!
- `hub-api.http` 파일에, 생성 -> 리스트조회 -> 단건조회 순으로 한번에 테스트해볼 수 있도록 추가해뒀습니다. 
- `HubId` 객체의 경우 필드가 1개인데 `HubId.builder().id(id).build();` 까지 너무 길어지는데 혹시 `정적 팩토리 메소드 생성자`도 도입을 하는 건 어떻게 생각하시나요? 아래 `여기!` 써진 곳을 보시면

```java
@Getter
@Embeddable
@EqualsAndHashCode
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class HubId implements Serializable { // JPA 식별자 타입은 Serializable 구현해야 함

    @Column(name = "id")
    private UUID id;

    public static HubId of(UUID id) {
        HubId hubId = new HubId();
        hubId.id = id;
        return hubId;
    }

    // 여기!
    public static HubId ofRandom() {
        HubId hubId = new HubId();
        hubId.id = UUID.randomUUID();
        return hubId;
    }
}
```

```java
@Getter
@Entity
@Table(name = "p_hub")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Hub extends BaseEntity {

    @EmbeddedId
    private final HubId id = HubId.ofRandom(); // 여기!
    // ...
}
```
- 이렇게 `of(UUID id)` 로 요청으로 받은 `UUID`를 `HubId`로 변환하거나, `ofRandom()` 으로 `id 생성기 역할`도 할 수 있을 것 같은데 이것도 논의해보면 좋을 것 같아요..!!

