### PR TITLE
gateway와 eureka 모듈 생성

### DIFF
--- a/application/auth/build.gradle
+++ b/application/auth/build.gradle
@@ -9,22 +9,7 @@ repositories {
     mavenCentral()
 }
 
-ext {
-    set('springCloudVersion', "2023.0.3")
-}
-
-
 dependencies {
-
-    //security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-
-    //eureka
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-
-    //openFeign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-
 
     // spring validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -38,17 +23,10 @@ dependencies {
     // docker compose support
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
-    implementation(project(':component:component-jwt'))
+    implementation(project(':component:component-security'))
     implementation(project(':component:component-jpa'))
     implementation(project(':component:component-exception'))
 }
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
-}
-
 
 test {
     useJUnitPlatform()

--- a/application/auth/src/main/java/animal/auth/AuthApplication.java
+++ b/application/auth/src/main/java/animal/auth/AuthApplication.java
@@ -1,10 +1,13 @@
-package animal;
+package animal.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Import;
+import security.JwtUtil;
 
 @SpringBootApplication
+@Import(JwtUtil.class)
 @EnableFeignClients
 public class AuthApplication {
 

--- a/application/eureka/Dockerfile
+++ b/application/eureka/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:17-jdk-slim
+
+# 시간대 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN mkdir /app
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} /app/app.jar
+
+# 컨테이너 실행 시 prod 프로파일로 JAR 실행 (application-prod.properties를 넣어주어야 함)
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app/app.jar"]

--- a/application/eureka/build.gradle
+++ b/application/eureka/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+}
+
+group = 'ex'
+version = 'unspecified'
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "2023.0.3")
+}
+
+dependencies {
+    
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+test {
+    useJUnitPlatform()
+}

--- a/application/eureka/src/main/java/animal/eureka/EurekaApplication.java
+++ b/application/eureka/src/main/java/animal/eureka/EurekaApplication.java
@@ -1,0 +1,15 @@
+package animal.eureka;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+public class EurekaApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EurekaApplication.class, args);
+  }
+
+}

--- a/application/eureka/src/main/resources/application-dev.yml
+++ b/application/eureka/src/main/resources/application-dev.yml
@@ -1,0 +1,10 @@
+server:
+  port: 19090
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+  instance:
+    hostname: localhost

--- a/application/eureka/src/main/resources/application.yml
+++ b/application/eureka/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: eureka-server
+  profiles:
+    default: dev

--- a/application/gateway/Dockerfile
+++ b/application/gateway/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:17-jdk-slim
+
+# 시간대 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN mkdir /app
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} /app/app.jar
+
+# 컨테이너 실행 시 prod 프로파일로 JAR 실행 (application-prod.properties를 넣어주어야 함)
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app/app.jar"]

--- a/application/gateway/build.gradle
+++ b/application/gateway/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+}
+
+group = 'ex'
+version = 'unspecified'
+
+repositories {
+    mavenCentral()
+}
+
+
+dependencies {
+    //gateway
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+
+}
+
+
+test {
+    useJUnitPlatform()
+}

--- a/application/gateway/src/main/java/animal/gateway/GatewayApplication.java
+++ b/application/gateway/src/main/java/animal/gateway/GatewayApplication.java
@@ -1,0 +1,13 @@
+package animal.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(GatewayApplication.class, args);
+  }
+
+}

--- a/application/gateway/src/main/resources/application-dev.yml
+++ b/application/gateway/src/main/resources/application-dev.yml
@@ -1,0 +1,33 @@
+spring:
+  docker:
+    compose:
+      lifecycle-management: start_only # start_only, start_and_stop ??? ???, ??? ?? ? ???? ?? ??? ??? ? ??
+      start:
+        command: up
+      stop:
+        command: down
+        timeout: 1m
+      file: application/auth/docker-compose.yml
+
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+
+      routes:
+        - id: auth-service
+          uri: lb://auth-service
+          predicates:
+            - Path=/users
+          filters:
+            - name: OrderServiceLog
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+
+server:
+  port: 8080
+

--- a/application/gateway/src/main/resources/application.yml
+++ b/application/gateway/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: gateway-service
+  profiles:
+    default: dev

--- a/component/component-security/build.gradle
+++ b/component/component-security/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group = 'ex'
+version = 'unspecified'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api 'io.jsonwebtoken:jjwt:0.12.6'
+    api 'org.springframework.boot:spring-boot-starter-security'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/component/component-security/src/main/java/security/JwtUtil.java
+++ b/component/component-security/src/main/java/security/JwtUtil.java
@@ -1,0 +1,64 @@
+package security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JwtUtil {
+
+  public static final String AUTHORIZATION_HEADER = "Authorization";
+
+  public static final String BEARER_PREFIX = "Bearer ";
+  private final SecretKey secretKey;
+  @Value("${spring.application.name}")
+  private String issuer;
+  @Value("${jwt.secret.access-expiration}")
+  private long accessExpiration; // 60분
+
+  public JwtUtil(@Value("${jwt.secret.key}") String secretKey) {
+    this.secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secretKey));
+  }
+
+  public String createToken(String email, UserRole role) {
+    return BEARER_PREFIX + Jwts.builder()
+        .claim("email", email)
+        .claim("role", role.name())
+        .issuer(issuer)
+        .issuedAt(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  //토큰 유효성 검증
+    /*public Claims validateToken(String token) {
+
+    }*/
+
+  // calims  만료 기간 검증
+    /*public boolean validateClaims(Claims claims) {
+        return claims.getExpiration().after(new Date());
+    }*/
+
+  //jwt 추출
+  public String parseJwt(String bearerToken) {
+    //todo : 필터에서 header의 token을 인자로 넘겨줌으로 수정
+    //String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+
+  //claims 추출
+  public Claims parseClaims(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+  }
+}

--- a/component/component-security/src/main/java/security/UserRole.java
+++ b/component/component-security/src/main/java/security/UserRole.java
@@ -1,4 +1,4 @@
-package animal.domain;
+package security;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/component/component-security/src/main/java/security/UserRolePreAuthFilter.java
+++ b/component/component-security/src/main/java/security/UserRolePreAuthFilter.java
@@ -1,4 +1,4 @@
-package animal.filter;
+package security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,7 +26,7 @@ public class UserRolePreAuthFilter extends OncePerRequestFilter {
     if (username != null && rolesHeader != null) {
       List<SimpleGrantedAuthority> authorities = Arrays.stream(rolesHeader.split(","))
           .map(role -> new SimpleGrantedAuthority(role.trim()))
-          .collect(Collectors.toList());
+          .toList();
 
       UsernamePasswordAuthenticationToken authenticationToken =
           new UsernamePasswordAuthenticationToken(username, null, authorities);

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,14 @@ include 'application:order'
 include 'application:company'
 include 'application:notification'
 include 'application:auth'
+include 'application:gateway'
+include 'application:eureka'
+
+
 include 'common:common'
 include 'component:component-exception'
+include 'component:component-security'
 include 'component:component-jpa'
+
 findProject(':component:component-jpa')?.name = 'component-jpa'
 


### PR DESCRIPTION
## 개요

- gateway와 eureka application모듈 생성
- security  component 모듈 생성
--> 인증 필터와 jwtUtil클래스 추가

## 작업사항

- root 모듈에 gateway와 eureka모듈를 추가해 종속성을 관리

## 세부사항

- application 단에서 build.gradle로 종속성 추가가 되지 않아 root 모듈 build.gradle에서 관리
- openFeignClient기능 활성 어노테이션과 외부 모듈 객체를 import하는 작업이 필요

```java
@SpringBootApplication
@Import(JwtUtil.class)
@EnableFeignClients
public class AuthApplication {...}
``` 
외부 모듈 객체 의존성 주입이 되지 않는 이유 (import해야하는 이유)
https://www.notion.so/8ef162ac4f56486d86d1163e68a56263

## 이슈
- gateway는 web-starter와 webflux가 충돌되어 오류가 납니다. gateway는 다음 pr때 수정해서 올리도록 하겠습니다!
