### PR TITLE
feat: 매니저 조회 및 추가 API 구현 

### DIFF
--- a/application/hub/http/hub-api.http
+++ b/application/hub/http/hub-api.http
@@ -84,6 +84,57 @@ Content-Type: application/json
   client.global.set("HUB_ID", response.body.data.id); // HUB_ID 라는 변수에 response.body.data.id 값을 저장
 %}
 
+### 허브 매니저 추가
+POST {{URL}}/hubs/{{HUB_ID}}/managers/hub
+Content-Type: application/json
+
+{
+  "username": "hubmanager"
+}
+
+> {%
+  client.test("성공 응답은 200", () => client.assert(response.status === 200, "응답 상태가 200이어야 합니다."));
+%}
+
+### 허브 배송 매니저 추가
+POST {{URL}}/hubs/{{HUB_ID}}/managers/hub-delivery
+Content-Type: application/json
+
+{
+  "username": "delivery",
+  "slackId": "slackId"
+}
+
+> {%
+  client.test("성공 응답은 200", () => client.assert(response.status === 200, "응답 상태가 200이어야 합니다."));
+%}
+
+### 업체 배송 매니저 추가
+POST {{URL}}/hubs/{{HUB_ID}}/managers/company-delivery
+Content-Type: application/json
+
+{
+  "username": "delivery",
+  "slackId": "slackId"
+}
+
+> {%
+  client.test("성공 응답은 200", () => client.assert(response.status === 200, "응답 상태가 200이어야 합니다."));
+%}
+
+### 공급 업체 매니저 추가
+POST {{URL}}/hubs/{{HUB_ID}}/managers/provider-company
+Content-Type: application/json
+
+{
+  "username": "provider",
+  "slackId": "slackId"
+}
+
+> {%
+  client.test("성공 응답은 200", () => client.assert(response.status === 200, "응답 상태가 200이어야 합니다."));
+%}
+
 ### 재고 생성
 POST {{URL}}/hubs/{{HUB_ID}}/inventories
 Content-Type: application/json

--- a/application/hub/src/main/java/animal/application/HubService.java
+++ b/application/hub/src/main/java/animal/application/HubService.java
@@ -77,6 +77,6 @@ public class HubService {
 
     private Hub findHub(HubId hubId) {
         return hubRepository.findById(hubId)
-            .orElseThrow(() -> new GlobalException(ErrorCase.NOT_FOUND));
+            .orElseThrow(() -> new GlobalException(ErrorCase.HUB_NOT_FOUND));
     }
 }

--- a/application/hub/src/main/java/animal/application/InventoryService.java
+++ b/application/hub/src/main/java/animal/application/InventoryService.java
@@ -109,13 +109,13 @@ public class InventoryService {
 
     private Hub findHub(HubId hubId) {
         return hubRepository.findById(hubId)
-            .orElseThrow(() -> new GlobalException(ErrorCase.NOT_FOUND));
+            .orElseThrow(() -> new GlobalException(ErrorCase.HUB_NOT_FOUND));
     }
 
     private Inventory findInventory(InventoryId inventoryId, HubId hubId) {
         Hub hub = findHub(hubId);
 
         return hub.getInventory(inventoryId)
-            .orElseThrow(() -> new GlobalException(ErrorCase.NOT_FOUND));
+            .orElseThrow(() -> new GlobalException(ErrorCase.INVENTORY_NOT_FOUND));
     }
 }

--- a/application/hub/src/main/java/animal/application/ManagerService.java
+++ b/application/hub/src/main/java/animal/application/ManagerService.java
@@ -1,0 +1,105 @@
+package animal.application;
+
+import animal.domain.Hub;
+import animal.domain.HubId;
+import animal.domain.manager.CompanyDeliveryManager;
+import animal.domain.manager.HubDeliveryManager;
+import animal.domain.manager.HubManager;
+import animal.domain.manager.ProviderCompanyManager;
+import animal.domain.manager.SlackId;
+import animal.domain.manager.Username;
+import animal.dto.HubResponse.GetHubRes;
+import animal.dto.ManagerRequest.AddCompanyDeliveryManagerReq;
+import animal.dto.ManagerRequest.AddHubDeliveryManagerReq;
+import animal.dto.ManagerRequest.AddHubManagerReq;
+import animal.dto.ManagerRequest.AddProviderCompanyManagerReq;
+import animal.infrastructure.HubRepository;
+import animal.mapper.HubMapper;
+import exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import response.ErrorCase;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ManagerService {
+
+    private final HubMapper hubMapper;
+    private final HubRepository hubRepository;
+
+    /**
+     * 허브 관리자 추가
+     */
+    public GetHubRes addHubManager(HubId hubId, AddHubManagerReq request) {
+
+        Hub hub = findHub(hubId);
+
+        HubManager hubManager = HubManager.builder()
+            .username(Username.of(request.username()))
+            .build();
+
+        hub.addHubManager(hubManager);
+
+        return hubMapper.toGetHubRes(hub);
+    }
+
+    /**
+     * 허브 배송 관리자 추가
+     */
+    public GetHubRes addHubDeliveryManager(HubId hubId, AddHubDeliveryManagerReq request) {
+
+        Hub hub = findHub(hubId);
+
+        HubDeliveryManager hubDeliveryManager = HubDeliveryManager.builder()
+            .username(Username.of(request.username()))
+            .slackId(SlackId.of(request.slackId()))
+            .build();
+
+        hub.addHubDeliveryManager(hubDeliveryManager);
+
+        return hubMapper.toGetHubRes(hub);
+    }
+
+    /**
+     * 업체 배송 관리자 추가
+     */
+    public GetHubRes addCompanyDeliveryManager(HubId hubId, AddCompanyDeliveryManagerReq request) {
+
+        Hub hub = findHub(hubId);
+
+        CompanyDeliveryManager companyDeliveryManager = CompanyDeliveryManager.builder()
+            .username(Username.of(request.username()))
+            .slackId(SlackId.of(request.slackId()))
+            .build();
+
+        hub.addCompanyDeliveryManager(companyDeliveryManager);
+
+        return hubMapper.toGetHubRes(hub);
+    }
+
+    /**
+     * 공급 업체 관리자 추가
+     */
+    public GetHubRes addProviderCompanyManager(HubId hubId, AddProviderCompanyManagerReq request) {
+
+        Hub hub = findHub(hubId);
+
+        ProviderCompanyManager providerCompanyManager = ProviderCompanyManager.builder()
+            .username(Username.of(request.username()))
+            .slackId(SlackId.of(request.slackId()))
+            .build();
+
+        hub.addProviderCompanyManager(providerCompanyManager);
+
+        return hubMapper.toGetHubRes(hub);
+    }
+
+    private Hub findHub(HubId hubId) {
+        return hubRepository.findById(hubId)
+            .orElseThrow(() -> new GlobalException(ErrorCase.HUB_NOT_FOUND));
+    }
+}

--- a/application/hub/src/main/java/animal/domain/Hub.java
+++ b/application/hub/src/main/java/animal/domain/Hub.java
@@ -1,10 +1,19 @@
 package animal.domain;
 
+import animal.domain.manager.CompanyDeliveryManager;
+import animal.domain.manager.HubDeliveryManager;
+import animal.domain.manager.HubManager;
+import animal.domain.manager.ProviderCompanyManager;
 import animal.jpa.BaseEntity;
+import exception.GlobalException;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
@@ -14,12 +23,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import response.ErrorCase;
 
 @Getter
 @Entity
 @Table(name = "p_hub")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Hub extends BaseEntity {
+
+    private static final int MAX_COMPANY_DELIVERY_MANAGER_COUNT = 10;
 
     @EmbeddedId
     private final HubId id = HubId.ofRandom();
@@ -32,6 +44,22 @@ public class Hub extends BaseEntity {
 
     @OneToMany(mappedBy = "hub", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<Inventory> inventoryList = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "p_hub_managaer", joinColumns = @JoinColumn(name = "hub_manager_id"))
+    private List<HubManager> hubManagerList = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "p_hub_delivery_managaer", joinColumns = @JoinColumn(name = "hub_delivery_manager_id"))
+    private List<HubDeliveryManager> hubDeliveryManagerList = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "p_company_delivery_managaer", joinColumns = @JoinColumn(name = "company_delivery_manager_id"))
+    private List<CompanyDeliveryManager> companyDeliveryManagerList = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "p_provider_company_manager", joinColumns = @JoinColumn(name = "provider_company_manager_id"))
+    private List<ProviderCompanyManager> providerCompanyManagerList = new ArrayList<>();
 
     @Builder
     private Hub(Address address, Coordinate coordinate) {
@@ -69,5 +97,41 @@ public class Hub extends BaseEntity {
      */
     public void removeInventory(InventoryId inventoryId) {
         inventoryList.removeIf(inventory -> inventory.getId().equals(inventoryId));
+    }
+
+    /**
+     * 허브 매니저 추가
+     */
+    public void addHubManager(HubManager hubManager) {
+        hubManagerList.add(hubManager);
+    }
+
+    /**
+     * 허브 배송 매니저 추가
+     */
+    public void addHubDeliveryManager(HubDeliveryManager hubDeliveryManager) {
+        hubDeliveryManagerList.add(hubDeliveryManager);
+    }
+
+    /**
+     * 업체 배송 매니저 추가
+     */
+    public void addCompanyDeliveryManager(CompanyDeliveryManager companyDeliveryManager) {
+        if (isCompanyDeliveryManagerOverLimit()) {
+            throw new GlobalException(ErrorCase.COMPANY_DELIVERY_MANAGER_OVER_LIMIT);
+        }
+
+        companyDeliveryManagerList.add(companyDeliveryManager);
+    }
+
+    private boolean isCompanyDeliveryManagerOverLimit() {
+        return companyDeliveryManagerList.size() >= MAX_COMPANY_DELIVERY_MANAGER_COUNT;
+    }
+
+    /**
+     * 생산 업체 매니저 추가
+     */
+    public void addProviderCompanyManager(ProviderCompanyManager providerCompanyManager) {
+        providerCompanyManagerList.add(providerCompanyManager);
     }
 }

--- a/application/hub/src/main/java/animal/domain/Inventory.java
+++ b/application/hub/src/main/java/animal/domain/Inventory.java
@@ -1,5 +1,6 @@
 package animal.domain;
 
+import animal.jpa.BaseEntity;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -8,7 +9,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jpa.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/application/hub/src/main/java/animal/domain/manager/CompanyDeliveryManager.java
+++ b/application/hub/src/main/java/animal/domain/manager/CompanyDeliveryManager.java
@@ -1,0 +1,28 @@
+package animal.domain.manager;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyDeliveryManager {
+
+    @Embedded
+    private Username username;
+
+    @Embedded
+    private SlackId slackId;
+
+    @Builder
+    private CompanyDeliveryManager(Username username, SlackId slackId) {
+        this.username = username;
+        this.slackId = slackId;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/manager/HubDeliveryManager.java
+++ b/application/hub/src/main/java/animal/domain/manager/HubDeliveryManager.java
@@ -1,0 +1,28 @@
+package animal.domain.manager;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubDeliveryManager {
+
+    @Embedded
+    private Username username;
+
+    @Embedded
+    private SlackId slackId;
+
+    @Builder
+    private HubDeliveryManager(Username username, SlackId slackId) {
+        this.username = username;
+        this.slackId = slackId;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/manager/HubManager.java
+++ b/application/hub/src/main/java/animal/domain/manager/HubManager.java
@@ -1,0 +1,24 @@
+package animal.domain.manager;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubManager {
+
+    @Embedded
+    private Username username;
+
+    @Builder
+    private HubManager(Username username) {
+        this.username = username;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/manager/ProviderCompanyManager.java
+++ b/application/hub/src/main/java/animal/domain/manager/ProviderCompanyManager.java
@@ -1,0 +1,28 @@
+package animal.domain.manager;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProviderCompanyManager {
+
+    @Embedded
+    private Username username;
+
+    @Embedded
+    private SlackId slackId;
+
+    @Builder
+    private ProviderCompanyManager(Username username, SlackId slackId) {
+        this.username = username;
+        this.slackId = slackId;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/manager/SlackId.java
+++ b/application/hub/src/main/java/animal/domain/manager/SlackId.java
@@ -1,0 +1,27 @@
+package animal.domain.manager;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SlackId {
+
+    private String slackId;
+
+    public static SlackId of(String slackId) {
+        SlackId id = new SlackId();
+        id.slackId = slackId;
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return slackId;
+    }
+}

--- a/application/hub/src/main/java/animal/domain/manager/SlackId.java
+++ b/application/hub/src/main/java/animal/domain/manager/SlackId.java
@@ -1,10 +1,13 @@
 package animal.domain.manager;
 
+import exception.GlobalException;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+import response.ErrorCase;
 
 @Getter
 @Embeddable
@@ -15,6 +18,10 @@ public class SlackId {
     private String slackId;
 
     public static SlackId of(String slackId) {
+        if (!StringUtils.hasText(slackId)) {
+            throw new GlobalException(ErrorCase.INVALID_INPUT);
+        }
+
         SlackId id = new SlackId();
         id.slackId = slackId;
         return id;

--- a/application/hub/src/main/java/animal/domain/manager/Username.java
+++ b/application/hub/src/main/java/animal/domain/manager/Username.java
@@ -1,0 +1,36 @@
+package animal.domain.manager;
+
+import exception.GlobalException;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import response.ErrorCase;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Username {
+
+    private static final Pattern pattern = Pattern.compile("^[a-z0-9]{4,10}$");
+
+    private String username;
+
+    public static Username of(String username) {
+        if (!pattern.matcher(username).matches()) {
+            throw new GlobalException(ErrorCase.INVALID_INPUT);
+        }
+
+        Username name = new Username();
+        name.username = username;
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return username;
+    }
+}

--- a/application/hub/src/main/java/animal/dto/HubResponse.java
+++ b/application/hub/src/main/java/animal/dto/HubResponse.java
@@ -2,10 +2,10 @@ package animal.dto;
 
 import animal.domain.Address;
 import animal.domain.Coordinate;
-import animal.domain.manager.CompanyDeliveryManager;
-import animal.domain.manager.HubDeliveryManager;
-import animal.domain.manager.HubManager;
-import animal.domain.manager.ProviderCompanyManager;
+import animal.dto.ManagerResponse.GetCompanyDeliveryManagerRes;
+import animal.dto.ManagerResponse.GetHubDeliveryManagerRes;
+import animal.dto.ManagerResponse.GetHubManagerRes;
+import animal.dto.ManagerResponse.GetProviderCompanyManagerRes;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,10 +15,10 @@ public class HubResponse {
         UUID id,
         Address address,
         Coordinate coordinate,
-        List<HubManager> hubManagerList,
-        List<HubDeliveryManager> hubDeliveryManagerList,
-        List<CompanyDeliveryManager> companyDeliveryManagerList,
-        List<ProviderCompanyManager> providerCompanyManagerList
+        List<GetHubManagerRes> hubManagerList,
+        List<GetHubDeliveryManagerRes> hubDeliveryManagerList,
+        List<GetCompanyDeliveryManagerRes> companyDeliveryManagerList,
+        List<GetProviderCompanyManagerRes> providerCompanyManagerList
     ) {
 
     }
@@ -27,10 +27,10 @@ public class HubResponse {
         UUID id,
         Address address,
         Coordinate coordinate,
-        List<HubManager> hubManagerList,
-        List<HubDeliveryManager> hubDeliveryManagerList,
-        List<CompanyDeliveryManager> companyDeliveryManagerList,
-        List<ProviderCompanyManager> providerCompanyManagerList
+        List<GetHubManagerRes> hubManagerList,
+        List<GetHubDeliveryManagerRes> hubDeliveryManagerList,
+        List<GetCompanyDeliveryManagerRes> companyDeliveryManagerList,
+        List<GetProviderCompanyManagerRes> providerCompanyManagerList
     ) {
 
     }
@@ -39,10 +39,10 @@ public class HubResponse {
         UUID id,
         Address address,
         Coordinate coordinate,
-        List<HubManager> hubManagerList,
-        List<HubDeliveryManager> hubDeliveryManagerList,
-        List<CompanyDeliveryManager> companyDeliveryManagerList,
-        List<ProviderCompanyManager> providerCompanyManagerList
+        List<GetHubManagerRes> hubManagerList,
+        List<GetHubDeliveryManagerRes> hubDeliveryManagerList,
+        List<GetCompanyDeliveryManagerRes> companyDeliveryManagerList,
+        List<GetProviderCompanyManagerRes> providerCompanyManagerList
     ) {
 
     }

--- a/application/hub/src/main/java/animal/dto/HubResponse.java
+++ b/application/hub/src/main/java/animal/dto/HubResponse.java
@@ -2,6 +2,11 @@ package animal.dto;
 
 import animal.domain.Address;
 import animal.domain.Coordinate;
+import animal.domain.manager.CompanyDeliveryManager;
+import animal.domain.manager.HubDeliveryManager;
+import animal.domain.manager.HubManager;
+import animal.domain.manager.ProviderCompanyManager;
+import java.util.List;
 import java.util.UUID;
 
 public class HubResponse {
@@ -9,7 +14,11 @@ public class HubResponse {
     public record GetHubRes(
         UUID id,
         Address address,
-        Coordinate coordinate
+        Coordinate coordinate,
+        List<HubManager> hubManagerList,
+        List<HubDeliveryManager> hubDeliveryManagerList,
+        List<CompanyDeliveryManager> companyDeliveryManagerList,
+        List<ProviderCompanyManager> providerCompanyManagerList
     ) {
 
     }
@@ -17,7 +26,11 @@ public class HubResponse {
     public record CreateHubRes(
         UUID id,
         Address address,
-        Coordinate coordinate
+        Coordinate coordinate,
+        List<HubManager> hubManagerList,
+        List<HubDeliveryManager> hubDeliveryManagerList,
+        List<CompanyDeliveryManager> companyDeliveryManagerList,
+        List<ProviderCompanyManager> providerCompanyManagerList
     ) {
 
     }
@@ -25,7 +38,11 @@ public class HubResponse {
     public record UpdateHubRes(
         UUID id,
         Address address,
-        Coordinate coordinate
+        Coordinate coordinate,
+        List<HubManager> hubManagerList,
+        List<HubDeliveryManager> hubDeliveryManagerList,
+        List<CompanyDeliveryManager> companyDeliveryManagerList,
+        List<ProviderCompanyManager> providerCompanyManagerList
     ) {
 
     }

--- a/application/hub/src/main/java/animal/dto/ManagerRequest.java
+++ b/application/hub/src/main/java/animal/dto/ManagerRequest.java
@@ -1,0 +1,31 @@
+package animal.dto;
+
+public class ManagerRequest {
+
+    public record AddHubManagerReq(
+        String username
+    ) {
+
+    }
+
+    public record AddHubDeliveryManagerReq(
+        String username,
+        String slackId
+    ) {
+
+    }
+
+    public record AddCompanyDeliveryManagerReq(
+        String username,
+        String slackId
+    ) {
+
+    }
+
+    public record AddProviderCompanyManagerReq(
+        String username,
+        String slackId
+    ) {
+
+    }
+}

--- a/application/hub/src/main/java/animal/dto/ManagerResponse.java
+++ b/application/hub/src/main/java/animal/dto/ManagerResponse.java
@@ -1,0 +1,31 @@
+package animal.dto;
+
+public class ManagerResponse {
+
+    public record GetHubManagerRes(
+        String username
+    ) {
+
+    }
+
+    public record GetHubDeliveryManagerRes(
+        String username,
+        String slackId
+    ) {
+
+    }
+
+    public record GetCompanyDeliveryManagerRes(
+        String username,
+        String slackId
+    ) {
+
+    }
+
+    public record GetProviderCompanyManagerRes(
+        String username,
+        String slackId
+    ) {
+
+    }
+}

--- a/application/hub/src/main/java/animal/mapper/HubMapper.java
+++ b/application/hub/src/main/java/animal/mapper/HubMapper.java
@@ -3,10 +3,18 @@ package animal.mapper;
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
 import animal.domain.Hub;
+import animal.domain.manager.CompanyDeliveryManager;
+import animal.domain.manager.HubDeliveryManager;
+import animal.domain.manager.HubManager;
+import animal.domain.manager.ProviderCompanyManager;
 import animal.dto.HubRequest.CreateHubReq;
 import animal.dto.HubResponse.CreateHubRes;
 import animal.dto.HubResponse.GetHubRes;
 import animal.dto.HubResponse.UpdateHubRes;
+import animal.dto.ManagerResponse.GetCompanyDeliveryManagerRes;
+import animal.dto.ManagerResponse.GetHubDeliveryManagerRes;
+import animal.dto.ManagerResponse.GetHubManagerRes;
+import animal.dto.ManagerResponse.GetProviderCompanyManagerRes;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -26,4 +34,19 @@ public interface HubMapper {
 
     @Mapping(target = "id", source = "id.id")
     UpdateHubRes toUpdateHubRes(Hub hub);
+    
+    @Mapping(target = "username", source = "username.username")
+    GetHubManagerRes toGetHubManagerRes(HubManager hubManager);
+
+    @Mapping(target = "username", source = "username.username")
+    @Mapping(target = "slackId", source = "slackId.slackId")
+    GetHubDeliveryManagerRes toGetHubDeliveryManagerRes(HubDeliveryManager hubDeliveryManager);
+
+    @Mapping(target = "username", source = "username.username")
+    @Mapping(target = "slackId", source = "slackId.slackId")
+    GetCompanyDeliveryManagerRes toGetCompanyDeliveryManagerRes(CompanyDeliveryManager companyDeliveryManager);
+
+    @Mapping(target = "username", source = "username.username")
+    @Mapping(target = "slackId", source = "slackId.slackId")
+    GetProviderCompanyManagerRes toGetProviderCompanyManagerRes(ProviderCompanyManager providerCompanyManager);
 }

--- a/application/hub/src/main/java/animal/presentation/ManagerController.java
+++ b/application/hub/src/main/java/animal/presentation/ManagerController.java
@@ -1,0 +1,75 @@
+package animal.presentation;
+
+import animal.application.ManagerService;
+import animal.domain.HubId;
+import animal.dto.HubResponse.GetHubRes;
+import animal.dto.ManagerRequest.AddCompanyDeliveryManagerReq;
+import animal.dto.ManagerRequest.AddHubDeliveryManagerReq;
+import animal.dto.ManagerRequest.AddHubManagerReq;
+import animal.dto.ManagerRequest.AddProviderCompanyManagerReq;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import response.CommonResponse;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hubs/{hubId}/managers")
+public class ManagerController {
+
+    private final ManagerService managerService;
+
+    /**
+     * 허브 관리자 추가
+     */
+    @PostMapping("/hub")
+    public CommonResponse<GetHubRes> addHubManager(
+        @PathVariable("hubId") UUID hubId,
+        @RequestBody AddHubManagerReq request
+    ) {
+        GetHubRes response = managerService.addHubManager(HubId.of(hubId), request);
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 허브 배송 관리자 추가
+     */
+    @PostMapping("/hub-delivery")
+    public CommonResponse<GetHubRes> addHubDeliveryManager(
+        @PathVariable("hubId") UUID hubId,
+        @RequestBody AddHubDeliveryManagerReq request
+    ) {
+        GetHubRes response = managerService.addHubDeliveryManager(HubId.of(hubId), request);
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 업체 배송 관리자 추가
+     */
+    @PostMapping("/company-delivery")
+    public CommonResponse<GetHubRes> addCompanyDeliveryManager(
+        @PathVariable("hubId") UUID hubId,
+        @RequestBody AddCompanyDeliveryManagerReq request
+    ) {
+        GetHubRes response = managerService.addCompanyDeliveryManager(HubId.of(hubId), request);
+        return CommonResponse.success(response);
+    }
+
+    /**
+     * 업체 관리자 추가
+     */
+    @PostMapping("/provider-company")
+    public CommonResponse<GetHubRes> addCompanyManager(
+        @PathVariable("hubId") UUID hubId,
+        @RequestBody AddProviderCompanyManagerReq request
+    ) {
+        GetHubRes response = managerService.addProviderCompanyManager(HubId.of(hubId), request);
+        return CommonResponse.success(response);
+    }
+}

--- a/common/common/src/main/java/response/ErrorCase.java
+++ b/common/common/src/main/java/response/ErrorCase.java
@@ -34,7 +34,17 @@ public enum ErrorCase {
     // 존재하지 않는 업체 404
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, 3000, "업체를 찾을 수 없습니다."),
 
-    ;
+
+    /* 허브 4000번대 */
+
+    // 존재하지 않는 허브 404
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "허브를 찾을 수 없습니다."),
+    // 존재하지 않는 재고 404
+    INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4001, "재고를 찾을 수 없습니다."),
+    // 업체 배송 매니저 추가 제한 초과 400
+    COMPANY_DELIVERY_MANAGER_OVER_LIMIT(HttpStatus.BAD_REQUEST, 4002, "업체 배송 매니저 추가 제한을 초과했습니다."),
+    // 허브 배송 매니저 추가 제한 초과 400
+    HUB_DELIVERY_MANAGER_OVER_LIMIT(HttpStatus.BAD_REQUEST, 4003, "허브 배송 매니저 추가 제한을 초과했습니다.");
 
     private final HttpStatus httpStatus; // 응답 상태 코드
     private final Integer code; // 응답 코드. 도메인에 따라 1000번대로 나뉨


### PR DESCRIPTION
## 개요

- 허브 매니저 조회, 추가 API 추가 

## 작업사항

- 매니저 추가 
  - 허브 매니저
  - 허브 배송 매니저
  - 업체 배송 매니저
  - 업체 매니저
- API 추가 
  - 매니저 리스트 조회 API 추가 
  - 각 매니저 추가 API 추가 
- 매니저 추가 HTTP 테스트 추가 

## 세부사항

- 혹시 변수명 더 좋은 거 있으면 추천받습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
  - 허브 관리자 추가를 위한 새로운 API 엔드포인트 추가 (허브 관리자, 허브 배달 관리자, 회사 배달 관리자, 제공업체 회사 관리자).
  - 다양한 관리자 유형을 추가할 수 있는 기능을 통해 허브 관리 시스템의 기능 확장.
  - Slack ID를 관리하기 위한 새로운 `SlackId` 클래스 추가.

- **버그 수정**
  - 허브 및 재고를 찾지 못할 경우 더 구체적인 오류 메시지 제공.

- **문서화**
  - 새로운 데이터 전송 객체(DTO) 및 응답 클래스 추가로 관리자 관련 데이터 구조 개선.

- **기타**
  - 오류 처리 개선을 위한 새로운 오류 케이스 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->