### PR TITLE
feat: 알림 도메인 추가 

### DIFF
--- a/application/notification/src/main/java/animal/application/notification/NotificationApplication.java
+++ b/application/notification/src/main/java/animal/application/notification/NotificationApplication.java
@@ -1,4 +1,4 @@
-package ex;
+package animal.application.notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/application/notification/src/main/java/animal/application/notification/application/NotificationSendService.java
+++ b/application/notification/src/main/java/animal/application/notification/application/NotificationSendService.java
@@ -1,0 +1,36 @@
+package animal.application.notification.application;
+
+import animal.application.notification.domain.Platform;
+import animal.application.notification.domain.Prompt;
+import animal.application.notification.implementation.NotificationSaver;
+import animal.application.notification.implementation.NotificationSender;
+import animal.application.notification.implementation.PromptCreator;
+import animal.application.notification.implementation.PromptSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSendService {
+
+    private final PromptSender promptSender;
+    private final PromptCreator promptCreator;
+    private final NotificationSaver notificationSaver;
+    private final NotificationSender notificationSender;
+
+    /**
+     * 메시지 전송
+     */
+    @Transactional
+    public void sendNotification(String recipientId, String requestMessage) {
+
+        String responseMessage = promptSender.send(requestMessage);
+        notificationSender.send(recipientId, responseMessage);
+
+        Prompt prompt = promptCreator.create(requestMessage, responseMessage);
+        notificationSaver.save(recipientId, Platform.SLACK, prompt);
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/config/PropertyConfig.java
+++ b/application/notification/src/main/java/animal/application/notification/config/PropertyConfig.java
@@ -1,0 +1,10 @@
+package animal.application.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan("animal.application.notification")
+public class PropertyConfig {
+
+}

--- a/application/notification/src/main/java/animal/application/notification/config/RestTemplateConfig.java
+++ b/application/notification/src/main/java/animal/application/notification/config/RestTemplateConfig.java
@@ -1,0 +1,24 @@
+package animal.application.notification.config;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    private static final int CONNECTION_TIMEOUT = 10;
+    private static final int READ_TIMEOUT = 10;
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+            // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+            // 무한 대기 상태 방지를 위해 강제 종료 설정
+            .setConnectTimeout(Duration.ofSeconds(CONNECTION_TIMEOUT))
+            .setReadTimeout(Duration.ofSeconds(READ_TIMEOUT))
+            .build();
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/domain/Notification.java
+++ b/application/notification/src/main/java/animal/application/notification/domain/Notification.java
@@ -1,0 +1,40 @@
+package animal.application.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    private final UUID id = UUID.randomUUID();
+
+    @Column(name = "message", length = 1000)
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    private Platform platform;
+
+    @OneToOne
+    private Prompt prompt;
+
+    @Builder
+    private Notification(String message, Platform platform, Prompt prompt) {
+        this.message = message;
+        this.platform = platform;
+        this.prompt = prompt;
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/domain/Platform.java
+++ b/application/notification/src/main/java/animal/application/notification/domain/Platform.java
@@ -1,0 +1,8 @@
+package animal.application.notification.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Platform {
+    SLACK
+}

--- a/application/notification/src/main/java/animal/application/notification/domain/Prompt.java
+++ b/application/notification/src/main/java/animal/application/notification/domain/Prompt.java
@@ -1,0 +1,33 @@
+package animal.application.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_prompt")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Prompt {
+
+    @Id
+    private final UUID id = UUID.randomUUID();
+
+    @Column(name = "request_content", length = 1000)
+    private String requestContent;
+
+    @Column(name = "response_content", length = 3000)
+    private String responseContent;
+
+    @Builder
+    private Prompt(String requestContent, String responseContent) {
+        this.requestContent = requestContent;
+        this.responseContent = responseContent;
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/implementation/NotificationSaver.java
+++ b/application/notification/src/main/java/animal/application/notification/implementation/NotificationSaver.java
@@ -1,0 +1,30 @@
+package animal.application.notification.implementation;
+
+import animal.application.notification.domain.Notification;
+import animal.application.notification.domain.Platform;
+import animal.application.notification.domain.Prompt;
+import animal.application.notification.infrastructure.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSaver {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public Notification save(String message, Platform platform, Prompt prompt) {
+
+        Notification notification = Notification.builder()
+            .message(message)
+            .platform(platform)
+            .prompt(prompt)
+            .build();
+
+        return notificationRepository.save(notification);
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/implementation/NotificationSender.java
+++ b/application/notification/src/main/java/animal/application/notification/implementation/NotificationSender.java
@@ -1,0 +1,21 @@
+package animal.application.notification.implementation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSender {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final RestTemplate restTemplate;
+
+    public void send(String slackId, String message) {
+        // TODO: 슬랙에 전송
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/implementation/PromptCreator.java
+++ b/application/notification/src/main/java/animal/application/notification/implementation/PromptCreator.java
@@ -1,0 +1,18 @@
+package animal.application.notification.implementation;
+
+import animal.application.notification.domain.Prompt;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class PromptCreator {
+
+    public Prompt create(String requestContent, String responseContent) {
+
+        return Prompt.builder()
+            .requestContent(requestContent)
+            .responseContent(responseContent)
+            .build();
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/implementation/PromptSender.java
+++ b/application/notification/src/main/java/animal/application/notification/implementation/PromptSender.java
@@ -1,0 +1,93 @@
+package animal.application.notification.implementation;
+
+import animal.application.notification.property.AiProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PromptSender {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final AiProperty aiProperty;
+    private final RestTemplate restTemplate;
+
+    /**
+     * RestTemplate 이용 API 요청메소드
+     */
+    public String send(String requestContent) {
+
+        HttpEntity<PromptReq> request = createHttpEntity(requestContent);
+        ResponseEntity<String> response = sendToAiApi(request);
+
+        return extractPrompt(response.getBody());
+    }
+
+    private HttpEntity<PromptReq> createHttpEntity(String requestContent) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        PromptReq promptReq = new PromptReq(List.of(new PromptReq.Content(List.of(new PromptReq.Part(requestContent)))));
+        return new HttpEntity<>(promptReq, headers);
+    }
+
+    private ResponseEntity<String> sendToAiApi(HttpEntity<PromptReq> requestEntity) {
+
+        return restTemplate.exchange(
+            aiProperty.getUrlWithKey(),
+            HttpMethod.POST,
+            requestEntity,
+            String.class
+        );
+    }
+
+    /**
+     * API response 에서 text 추출하는 메소드
+     */
+    private String extractPrompt(String responseBody) {
+        try {
+            return objectMapper.readTree(responseBody)
+                .path("candidates")
+                .path(0)
+                .path("content")
+                .path("parts")
+                .path(0)
+                .path("text")
+                .asText("");
+        } catch (JsonProcessingException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Prompt API 요청 DTO
+     */
+    private record PromptReq(
+        List<Content> contents
+    ) {
+
+        private record Content(
+            List<Part> parts
+        ) {
+
+        }
+
+        private record Part(
+            String text
+        ) {
+
+        }
+    }
+}

--- a/application/notification/src/main/java/animal/application/notification/infrastructure/NotificationRepository.java
+++ b/application/notification/src/main/java/animal/application/notification/infrastructure/NotificationRepository.java
@@ -1,0 +1,9 @@
+package animal.application.notification.infrastructure;
+
+import animal.application.notification.domain.Notification;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+}

--- a/application/notification/src/main/java/animal/application/notification/property/AiProperty.java
+++ b/application/notification/src/main/java/animal/application/notification/property/AiProperty.java
@@ -1,0 +1,14 @@
+package animal.application.notification.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("ai.api")
+public record AiProperty(
+    String url,
+    String key
+) {
+
+    public String getUrlWithKey() {
+        return url + "?key=" + key;
+    }
+}

--- a/application/notification/src/main/resources/application-dev.yml
+++ b/application/notification/src/main/resources/application-dev.yml
@@ -4,8 +4,8 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:54325/animal
-    username: sa
-    password:
+    username: animal
+    password: 1234
   jpa:
     hibernate:
       ddl-auto: create
@@ -24,3 +24,13 @@ spring:
       file: application/notification/docker-compose.yml
 server:
   port: 8085
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+  instance:
+    hostname: localhost
+ai:
+  api:
+    url: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent
+    key: "${AI_API_KEY}"


### PR DESCRIPTION
## 개요

- 알림 도메인 일부를 추가했습니다. 

## 작업사항

- 알림 엔티티 추가
- 프롬프트 엔티티 추가 
- Gemini API로 전송하는 로직 추가
- 전송 관련 서비스 추가 

## 세부사항

- implementation 이라는 디렉토리가 하나 추가되었는데요, 바쁜만큼 습관적으로 빠르게 코드 작성하느라 나와버렸습니다..
- [여기](https://github.com/yun-studio/insight-backend/pull/1)에서 빠르게 감을 잡을 수 있는데, 일단 구현부터 하느라 컨벤션을 못 지킨 점 죄송합니다.. 
- implementation 계층은 하나의 작업만 하는 서비스이고, application 계층은 이를 조합하여 하나의 기능을 하는 서비스로 생각하시면 됩니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 알림 전송 서비스 추가: 사용자가 알림을 보낼 수 있도록 지원하는 기능.
  - 새로운 알림, 플랫폼, 프롬프트 데이터 모델 추가.
  - AI API와의 통신을 위한 프롬프트 전송 기능 추가.

- **구성 변경**
  - 애플리케이션 설정 파일 수정: 데이터베이스 연결 및 서비스 구성 변경.
  
- **버그 수정**
  - 코드베이스 정리 및 패키지 구조 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->